### PR TITLE
Avoid overriding function in Base since v1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -50,7 +50,7 @@ Base.isless(x) = Fix2(isless, x)
 islessequal(x) = Fix2(islessequal, x)
 isgreater(x) = Fix2(isgreater, x)
 isgreaterequal(x) = Fix2(isgreaterequal, x)
-if VERSION < v"1.2.0-"
+if VERSION < v"1.2.0-DEV.257"
     # Added to Base in https://github.com/JuliaLang/julia/pull/30915
     Base.:(<)(x) = Fix2(<, x)
     Base.:(<=)(x) = Fix2(<=, x)

--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -50,8 +50,11 @@ Base.isless(x) = Fix2(isless, x)
 islessequal(x) = Fix2(islessequal, x)
 isgreater(x) = Fix2(isgreater, x)
 isgreaterequal(x) = Fix2(isgreaterequal, x)
-Base.:(<)(x) = Fix2(<, x)
-Base.:(<=)(x) = Fix2(<=, x)
-Base.:(>)(x) = Fix2(>, x)
-Base.:(>=)(x) = Fix2(>=, x)
-Base.:(!=)(x) = Fix2(!=, x)
+if VERSION < v"1.2.0-"
+    # Added to Base in https://github.com/JuliaLang/julia/pull/30915
+    Base.:(<)(x) = Fix2(<, x)
+    Base.:(<=)(x) = Fix2(<=, x)
+    Base.:(>)(x) = Fix2(>, x)
+    Base.:(>=)(x) = Fix2(>=, x)
+    Base.:(!=)(x) = Fix2(!=, x)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,13 @@ using SplitApplyCombine
 
 @test isempty(detect_ambiguities(Base, AcceleratedArrays))
 
-include("Interval.jl")
-include("MaybeVector.jl")
-include("SingleVector.jl")
+@testset "AcceleratedArrays" begin
+    include("Interval.jl")
+    include("MaybeVector.jl")
+    include("SingleVector.jl")
 
-include("HashIndex.jl")
-include("UniqueHashIndex.jl")
-include("SortIndex.jl")
-include("UniqueSortIndex.jl")
+    include("HashIndex.jl")
+    include("UniqueHashIndex.jl")
+    include("SortIndex.jl")
+    include("UniqueSortIndex.jl")
+end


### PR DESCRIPTION
- This adds a version check to function we define that were since added to Base.
- Enables CI for 1.1 and 1.2 (these functions were added to Base in 1.2)
- ...and wraps the tests in a testset (this can be reverted / a separate PR if you prefer -- i just noticed it when running tests)

Warnings fixed by this change (in v"1.2.0-rc2.0"):
```julia
julia> using AcceleratedArrays
[ Info: Recompiling stale cache file /Users/nick/.julia/compiled/v1.2/AcceleratedArrays/mcm9V.ji for AcceleratedArrays [44e12807-9a19-5591-91cf-c1b4fb89ce64]
WARNING: Method definition <(Any) in module Base at operators.jl:1015 overwritten in module AcceleratedArrays at /Users/nick/.julia/packages/AcceleratedArrays/vPA4c/src/predicates.jl:53.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition <=(Any) in module Base at operators.jl:989 overwritten in module AcceleratedArrays at /Users/nick/.julia/packages/AcceleratedArrays/vPA4c/src/predicates.jl:54.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition >(Any) in module Base at operators.jl:1002 overwritten in module AcceleratedArrays at /Users/nick/.julia/packages/AcceleratedArrays/vPA4c/src/predicates.jl:55.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition >=(Any) in module Base at operators.jl:976 overwritten in module AcceleratedArrays at /Users/nick/.julia/packages/AcceleratedArrays/vPA4c/src/predicates.jl:56.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition !=(Any) in module Base at operators.jl:963 overwritten in module AcceleratedArrays at /Users/nick/.julia/packages/AcceleratedArrays/vPA4c/src/predicates.jl:57.
  ** incremental compilation may be fatally broken for this module **
```