### PR TITLE
Added option to skip checks on UniqueSortIndex

### DIFF
--- a/src/UniqueSortIndex.jl
+++ b/src/UniqueSortIndex.jl
@@ -1,4 +1,3 @@
-
 struct UniqueSortIndex{O <: AbstractVector} <: AbstractUniqueIndex
 	order::O
 end
@@ -21,6 +20,14 @@ function accelerate!(a::AbstractArray, ::Type{UniqueSortIndex})
 	    end
 	end
     return AcceleratedArray(a, UniqueSortIndex(keys(a)))
+end
+
+function accelerate(a::AbstractVector, ::Type{UniqueSortIndex}, check::Bool)
+    if check
+        accelerate(a, UniqueSortIndex)
+    else
+        AcceleratedArray(a, UniqueSortIndex(Base.OneTo(length(a))))
+    end
 end
 
 Base.summary(::UniqueSortIndex) = "UniqueSortIndex"


### PR DESCRIPTION
This is because I'm usually dealing with a known-sorted array, and want an easy interface to constructing an `AcceleratedArray` without any of the sorting & checks.

In terms of the interface: having a bool argument seemed quick and easy. Could instead add a new type `PreSorted` or something and dispatch on that as an argument, which would give type inference without relying on constant propagation.

I also thought about doing this for SortIndex, but noticed that it has the `n_unique` field + computation which makes things tricky. That field doesn't actually seem to ever be used in the package - could we ditch it?