### PR TITLE
Added getindex and view for UniqueSortIndex with a UnitRange

### DIFF
--- a/src/UniqueSortIndex.jl
+++ b/src/UniqueSortIndex.jl
@@ -326,12 +326,12 @@ function Base.findlast(f::Fix2{typeof(in), <:Interval}, a::AcceleratedArray{<:An
     end
 end
 
-function Base.getindex(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::UnitRange{Int})
+Base.@propagate_inbounds function Base.getindex(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::AbstractUnitRange{Int})
     a_i = getindex(parent(a), ind)
     AcceleratedArray(a_i, UniqueSortIndex(Base.OneTo(length(a_i))))
 end
 
-function Base.view(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::UnitRange{Int})
+Base.@propagate_inbounds function Base.view(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::AbstractUnitRange{Int})
     a_i = view(parent(a), ind)
     AcceleratedArray(a_i, UniqueSortIndex(Base.OneTo(length(a_i))))
 end

--- a/src/UniqueSortIndex.jl
+++ b/src/UniqueSortIndex.jl
@@ -326,6 +326,19 @@ function Base.findlast(f::Fix2{typeof(in), <:Interval}, a::AcceleratedArray{<:An
     end
 end
 
+function Base.getindex(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::UnitRange{Int})
+    a_i = getindex(parent(a), ind)
+    AcceleratedArray(a_i, UniqueSortIndex(Base.OneTo(length(a_i))))
+end
+
+function Base.view(a::AcceleratedVector{<:Any, <:Any, <:UniqueSortIndex{<:Base.OneTo}}, ind::UnitRange{Int})
+    a_i = view(parent(a), ind)
+    AcceleratedArray(a_i, UniqueSortIndex(Base.OneTo(length(a_i))))
+end
+
 # TODO - Grouping
 #      - Sort-merge joins
-#      - Sorted indexing preserves sortedness (including at least unit ranges)
+#      - Sorted indexing with StepRanges. Have to check step is positive and branch, so not type stable.
+#        Could allow a wrapper PositiveStep(steprange) that either returns a StepRange or errors, and is therefore type-stable
+#        Users could then index their AcceleratedArrays with PositiveStep(range) if they cared about stability
+#      - Sorted indexing with other known-sorted arrays of integers.


### PR DESCRIPTION
Implements indexing of a straightforwardly ordered UniqueSortIndex with a UnitRange. This is the case that comes up almost 100% of the time for me (usually taking a positive-step slice of an array indexed with some unique, increasing Dates).

I also looked at implementing for SortIndex, but was thrown off by the `n_unique` so left it for now.

The construction of the return AAs would also be made simpler if https://github.com/andyferris/AcceleratedArrays.jl/pull/10 merges.

I added some notes at the bottom for further TODOs. StepRanges are annoying because they retain sortedness depending on the sign of their step.