### PR TITLE
Add option for HashIndex & UniqueHashIndex to hash lazily

### DIFF
--- a/src/HashIndex.jl
+++ b/src/HashIndex.jl
@@ -1,41 +1,63 @@
 # Hash table acceleration index
-struct HashIndex{D <: HashDictionary} <: AbstractIndex
+mutable struct HashIndex{D <: HashDictionary,A <: AbstractArray} <: AbstractIndex
     dict::D
+    arr::A
+    initialised::Bool
 end
 
 function HashIndex(a::AbstractArray)
-    dict = HashDictionary{eltype(a), Vector{eltype(keys(a))}}()
-    
-    @inbounds for i in keys(a)
-        value = a[i]
-        vector = get!(Vector{eltype(keys(a))}, dict, value)
-        push!(vector, i)
-    end
+    dict = HashDictionary{eltype(a),Vector{eltype(keys(a))}}()
+    return HashIndex(dict, a, false)
+end
 
-    return HashIndex(dict)
+function initialised(index::HashIndex)
+    if !index.initialised
+        @inbounds for i in keys(index.arr)
+            value = index.arr[i]
+            vector = get!(Vector{eltype(keys(index.arr))}, index.dict, value)
+            push!(vector, i)
+        end
+        index.initialised = true
+    end
+    return index
+end
+
+getdict(index::HashIndex) = initialised(index).dict
+
+# Not lazy by default
+accelerate(a::AbstractArray, ::Type{HashIndex}) = accelerate(a, UniqueHashIndex, false)
+
+function accelerate(a::AbstractArray, ::Type{HashIndex}, lazy::Bool)
+    aa = AcceleratedArray(a, HashIndex(a))
+    if !lazy
+        initialised(aa.index)
+    end
+    return aa
 end
 
 # TODO: accelerate! by put elements in order so we can use ranges as dict values and dict
 #       iteration mirrors array iteration for cache friendliness?
 
-Base.summary(i::HashIndex) = "HashIndex ($(length(i.dict)) unique element$(length(i.dict) == 1 ? "" : "s"))"
+Base.summary(i::HashIndex) = "HashIndex ($(length(getdict(i))) unique element$(length(getdict(i)) == 1 ? "" : "s"))"
 
 # Accelerations
-Base.in(x, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex}) = haskey(a.index.dict, x)
+Base.in(x, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex}) = haskey(getdict(a.index), x)
 
-function Base.count(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.count(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return length(@inbounds gettokenvalue(a.index.dict, token))
+        return length(@inbounds gettokenvalue(dict, token))
     else
         return 0
     end
 end
 
-function Base.findall(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.findall(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return @inbounds gettokenvalue(a.index.dict, token)
+        return @inbounds gettokenvalue(dict, token)
     else
         return Vector{eltype(keys(a))}()
     end
@@ -43,28 +65,31 @@ end
 
 # TODO: findall for arbitrary predicates by just checking each unique key? (Sometimes faster, sometimes slower?)
 
-function Base.findfirst(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.findfirst(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return @inbounds first(gettokenvalue(a.index.dict, token))
+        return @inbounds first(gettokenvalue(dict, token))
     else
         return nothing
     end
 end
 
-function Base.findlast(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.findlast(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return @inbounds last(gettokenvalue(a.index.dict, token))
+        return @inbounds last(gettokenvalue(dict, token))
     else
         return nothing
     end
 end
 
-function Base.filter(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.filter(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return @inbounds parent(a)[(gettokenvalue(a.index.dict, token))]
+        return @inbounds parent(a)[(gettokenvalue(dict, token))]
     else
         return empty(a)
     end
@@ -72,35 +97,35 @@ end
 
 # TODO: filter for arbitrary predicates by just checking each unique key? (Sometimes faster, sometimes slower?)
 
-function Base.unique(a::AcceleratedArray{T, <:Any, <:Any, <:HashIndex}) where {T}
+function Base.unique(a::AcceleratedArray{T,<:Any,<:Any,<:HashIndex}) where {T}
     out = Vector{T}()
-    @inbounds for value in keys(a.index.dict)
+    @inbounds for value in keys(getdict(a.index))
         push!(out, value)
     end
     return out
 end
 
-function SplitApplyCombine.group(a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex}, b::AbstractArray)
-    return map(inds -> @inbounds(b[inds]), a.index.dict)
+function SplitApplyCombine.group(a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex}, b::AbstractArray)
+    return map(inds->@inbounds(b[inds]), getdict(a.index))
 end
 
-function SplitApplyCombine.groupreduce(op::Callable, a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex}; kw...)
-    return map(inds -> @inbounds(reduce(op, view(a, inds); kw...)), a.index.dict)
+function SplitApplyCombine.groupreduce(op::Callable, a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex}; kw...)
+    return map(inds->@inbounds(reduce(op, view(a, inds); kw...)), getdict(a.index))
 end
 
-function SplitApplyCombine.groupfind(a::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
-    return a.index.dict
+function SplitApplyCombine.groupfind(a::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
+    return getdict(a.index)
 end
 
-function SplitApplyCombine._innerjoin!(out, left::AbstractArray, right::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex}, v::AbstractArray, ::typeof(isequal))
+function SplitApplyCombine._innerjoin!(out, left::AbstractArray, right::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex}, v::AbstractArray, ::typeof(isequal))
     @boundscheck if (axes(left)..., axes(right)...) != axes(v)
         throw(DimensionMismatch("innerjoin arrays do not have matching dimensions"))
     end
 
-    dict = right.index.dict
+    dict = getdict(right.index)
 
     @inbounds for i_l ∈ keys(left)
-        (hasindex, token) = gettoken(right.index.dict, @inbounds left[i_l])
+        (hasindex, token) = gettoken(dict, @inbounds left[i_l])
         if hasindex
             for i_r ∈ gettokenvalue(dict, token)
                 push!(out, v[Tuple(i_l)..., Tuple(i_r)...])
@@ -111,15 +136,15 @@ function SplitApplyCombine._innerjoin!(out, left::AbstractArray, right::Accelera
     return out
 end
 
-function SplitApplyCombine.leftgroupjoin(lkey, ::typeof(identity), f, ::typeof(isequal), left, right::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
+function SplitApplyCombine.leftgroupjoin(lkey, ::typeof(identity), f, ::typeof(isequal), left, right::AcceleratedArray{<:Any,<:Any,<:Any,<:HashIndex})
     T = promote_op(f, eltype(left), eltype(right))
     K = promote_op(lkey, eltype(left))
 
-    dict = right.index.dict
-    out = HashDictionary{K, Vector{T}}()
+    dict = getdict(right.index)
+    out = HashDictionary{K,Vector{T}}()
     for a ∈ left
         key = lkey(a)
-        group = get!(() -> T[], out, key)
+        group = get!(()->T[], out, key)
         (hasindex, token) = gettoken(dict, key)
         if hasindex
             for b ∈ @inbounds gettokenvalue(dict, token)
@@ -130,7 +155,7 @@ function SplitApplyCombine.leftgroupjoin(lkey, ::typeof(identity), f, ::typeof(i
     return out
 end
 
-#=
+#= 
 function SplitApplyCombine.innerjoin(lkey, ::typeof(identity), f, ::typeof(isequal), left, right::AcceleratedArray{<:Any, <:Any, <:Any, <:HashIndex})
     T = promote_op(f, eltype(left), eltype(right))
     dict = right.index.dict
@@ -145,5 +170,4 @@ function SplitApplyCombine.innerjoin(lkey, ::typeof(identity), f, ::typeof(isequ
         end
     end
     return out
-end
-=#
+end =#

--- a/src/UniqueHashIndex.jl
+++ b/src/UniqueHashIndex.jl
@@ -1,71 +1,93 @@
 # Hash table acceleration index
-struct UniqueHashIndex{D <: HashDictionary} <: AbstractUniqueIndex
+mutable struct UniqueHashIndex{D <: HashDictionary,A <: AbstractArray} <: AbstractUniqueIndex
     dict::D
+    arr::A
+    initialised::Bool
 end 
 
 function UniqueHashIndex(a::AbstractArray)
-    dict = HashDictionary{eltype(a), SingleVector{eltype(keys(a))}}()
+    dict = HashDictionary{eltype(a),SingleVector{eltype(keys(a))}}()
+    return UniqueHashIndex(dict, a, false)
+end
 
-    @inbounds for i in keys(a)
-        value = a[i]
-        (hadindex, token) = gettoken!(dict, value)
-        if hadindex
-            error("Input not unique") # TODO Use appropriate Exception
-        else # `value` is ready to be inserted into `dict` at slot `-index`
-            @inbounds settokenvalue!(dict, token, SingleVector(i))
+function initialised(index::UniqueHashIndex)
+    if !index.initialised
+        @inbounds for i in keys(index.arr)
+            value = index.arr[i]
+            (hadindex, token) = gettoken!(index.dict, value)
+            if hadindex
+                error("Input not unique") # TODO Use appropriate Exception
+            else # `value` is ready to be inserted into `dict` at slot `-index`
+                @inbounds settokenvalue!(index.dict, token, SingleVector(i))
+            end
         end
+        index.initialised = true
     end
-    return UniqueHashIndex(dict)
+    return index
+end
+
+getdict(index::UniqueHashIndex) = initialised(index).dict
+
+# Not lazy by default
+accelerate(a::AbstractArray, ::Type{UniqueHashIndex}) = accelerate(a, UniqueHashIndex, false)
+
+function accelerate(a::AbstractArray, ::Type{UniqueHashIndex}, lazy::Bool)
+    aa = AcceleratedArray(a, UniqueHashIndex(a))
+    if !lazy
+        initialised(aa.index)
+    end
+    return aa
 end
 
 Base.summary(::UniqueHashIndex) = "UniqueHashIndex"
 
 # Accelerations
-Base.in(x, a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex}) = haskey(a.index.dict, x)
+Base.in(x, a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex}) = haskey(getdict(a.index), x)
 
-function Base.count(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex})
-    if f.x in keys(a.index.dict)
+function Base.count(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex})
+    if f.x in keys(getdict(a.index))
         return 1
     else
         return 0
     end
 end
 
-function Base.findall(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex})
-    (hasindex, token) = gettoken(a.index.dict, f.x)
+function Base.findall(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex})
+    dict = getdict(a.index)
+    (hasindex, token) = gettoken(dict, f.x)
     if hasindex
-        return MaybeVector(@inbounds gettokenvalue(a.index.dict, token)[])
+        return MaybeVector(@inbounds gettokenvalue(dict, token)[])
     else
         return MaybeVector{eltype(keys(a))}()
     end
 end
 
-function Base.filter(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex})
-    if f.x in keys(a.index.dict)
+function Base.filter(f::Fix2{typeof(isequal)}, a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex})
+    if f.x in keys(getdict(a.index))
         return MaybeVector{eltype(a)}(f.x)
     else
         return MaybeVector{eltype(a)}()
     end
 end
 
-function SplitApplyCombine.group(a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex}, b::AbstractArray)
-    return map(inds -> SingleVector(@inbounds b[inds[]]), a.index.dict)
+function SplitApplyCombine.group(a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex}, b::AbstractArray)
+    return map(inds->SingleVector(@inbounds b[inds[]]), getdict(a.index))
 end
 
-function SplitApplyCombine.groupreduce(::typeof(identity), f, op, a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex}; kw...)
-    return map(inds -> @inbounds(reduce(op, a[inds[]]; kw...)), a.index.dict)
+function SplitApplyCombine.groupreduce(::typeof(identity), f, op, a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex}; kw...)
+    return map(inds->@inbounds(reduce(op, a[inds[]]; kw...)), getdict(a.index))
 end
 
-function SplitApplyCombine.groupfind(a::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex})
-    return a.index.dict
+function SplitApplyCombine.groupfind(a::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex})
+    return getdict(a.index)
 end
 
-function SplitApplyCombine._innerjoin!(out, left::AbstractArray, right::AcceleratedArray{<:Any, <:Any, <:Any, <:UniqueHashIndex}, v::AbstractArray, ::typeof(isequal))
+function SplitApplyCombine._innerjoin!(out, left::AbstractArray, right::AcceleratedArray{<:Any,<:Any,<:Any,<:UniqueHashIndex}, v::AbstractArray, ::typeof(isequal))
     @boundscheck if (axes(left)..., axes(right)...) != axes(v)
         throw(DimensionMismatch("innerjoin arrays do not have matching dimensions"))
     end
 
-    dict = right.index.dict
+    dict = getdict(right.index)
 
     @inbounds for i_l ∈ keys(left)
         (hasindex, token) = gettoken(dict, left[i_l])

--- a/test/HashIndex.jl
+++ b/test/HashIndex.jl
@@ -1,26 +1,28 @@
 @testset "HashIndex" begin
-   a = [3, 1, 2, 1]
-   b = accelerate(a, HashIndex)
-   
-   @test 2 ∈ b
-   @test 0 ∉ b
+    for lazy in [true, false]
+        a = [3, 1, 2, 1]
+        b = accelerate(a, HashIndex, lazy)
+      
+        @test 2 ∈ b
+        @test 0 ∉ b
 
-   @test count(isequal(1), b) == 2
-   @test count(isequal(2), b) == 1
-   @test count(isequal(4), b) == 0
-   
-   @test findall(isequal(1), b) == [2, 4]
-   @test findall(isequal(4), b) == []
+        @test count(isequal(1), b) == 2
+        @test count(isequal(2), b) == 1
+        @test count(isequal(4), b) == 0
+      
+        @test findall(isequal(1), b) == [2, 4]
+        @test findall(isequal(4), b) == []
 
-   @test filter(isequal(1), b) == [1, 1]
-   @test filter(isequal(4), b) == []
+        @test filter(isequal(1), b) == [1, 1]
+        @test filter(isequal(4), b) == []
 
-   @test issetequal(unique(b), [1,2,3])
+        @test issetequal(unique(b), [1,2,3])
 
-   @test group(identity, b) == group(identity, a)
-   @test groupfind(identity, b) == groupfind(identity, a)
-   @test groupreduce(identity, +, b) == groupreduce(identity, +, a)
+        @test group(identity, b) == group(identity, a)
+        @test groupfind(identity, b) == groupfind(identity, a)
+        @test groupreduce(identity, +, b) == groupreduce(identity, +, a)
 
-   @test issetequal(innerjoin(identity, identity, tuple, isequal, b, [0, 1, 2]),
-                    innerjoin(identity, identity, tuple, isequal, a, [0, 1, 2]))
+        @test issetequal(innerjoin(identity, identity, tuple, isequal, b, [0, 1, 2]),
+                         innerjoin(identity, identity, tuple, isequal, a, [0, 1, 2]))
+    end
 end

--- a/test/UniqueHashIndex.jl
+++ b/test/UniqueHashIndex.jl
@@ -1,27 +1,29 @@
 @testset "UniqueHashIndex" begin
     @test_throws ErrorException accelerate([3, 1, 2, 1], UniqueHashIndex)
 
-    a = UInt[3, 1, 2]
-    b = accelerate(a, UniqueHashIndex)
+    for lazy in [true, false]
+        a = UInt[3, 1, 2]
+        b = accelerate(a, UniqueHashIndex, lazy)
 
-    @test 3 ∈ b
-    @test 4 ∉ b
+        @test 3 ∈ b
+        @test 4 ∉ b
 
-    @test count(isequal(3), b) == 1
-    @test count(isequal(4), b) == 0
+        @test count(isequal(3), b) == 1
+        @test count(isequal(4), b) == 0
 
-    @test findall(isequal(1), b)::MaybeVector{Int} == [2]
-    @test findall(isequal(4), b)::MaybeVector{Int} == []
+        @test findall(isequal(1), b)::MaybeVector{Int} == [2]
+        @test findall(isequal(4), b)::MaybeVector{Int} == []
 
-    @test filter(isequal(1), b)::MaybeVector{UInt} == [1]
-    @test filter(isequal(4), b)::MaybeVector{UInt} == []
+        @test filter(isequal(1), b)::MaybeVector{UInt} == [1]
+        @test filter(isequal(4), b)::MaybeVector{UInt} == []
 
-    @test unique(b) === b
+        @test unique(b) === b
 
-    @test group(iseven, b) == group(iseven, a)
-    @test groupfind(iseven, b) == groupfind(iseven, a)
-    @test groupreduce(iseven, +, b) == groupreduce(iseven, +, a)
+        @test group(iseven, b) == group(iseven, a)
+        @test groupfind(iseven, b) == groupfind(iseven, a)
+        @test groupreduce(iseven, +, b) == groupreduce(iseven, +, a)
 
-    @test issetequal(innerjoin(identity, identity, tuple, isequal, b, [0, 1, 2]),
-                     innerjoin(identity, identity, tuple, isequal, a, [0, 1, 2]))
+        @test issetequal(innerjoin(identity, identity, tuple, isequal, b, [0, 1, 2]),
+                         innerjoin(identity, identity, tuple, isequal, a, [0, 1, 2]))
+    end
 end


### PR DESCRIPTION
This is useful to me, and could be useful to others. I often have UniqueHashIndexes that never get indexed into into (either the indexing is more often happening on another dimension, or the indexing is a nice to have for interactive sessions).
This could also give us cheap views of HashIndex AcceleratedArrays - just take a view of the parent array and construct a lazy HashIndex from it.

Only downside is that there now has to be a small check every time the dictionary is accessed. This is acceptable to me, though it could maybe prevent certain optimisations in very loopy indexing code?
If it's a big deal, we could make these lazy variants separate types.

In terms of the code - tossed up whether to have a `Bool` field or a `Union{D,Nothing}` dictionary. The latter is nicer but seemed a little fiddlier.