### PR TITLE
Accelerate some more predicates (like ==)

### DIFF
--- a/src/predicates.jl
+++ b/src/predicates.jl
@@ -58,3 +58,16 @@ if VERSION < v"1.2.0-DEV.257"
     Base.:(>=)(x) = Fix2(>=, x)
     Base.:(!=)(x) = Fix2(!=, x)
 end
+
+# Search for other things that are == but not isequal (for example -0.0)
+other_equal(::Any) = ()
+other_equal(x::AbstractFloat) = isequal(x, 0.0) ? MaybeVector(convert(typeof(x), -0.0)) : isequal(x, -0.0) ? MaybeVector(convert(typeof(x), 0.0)) : MaybeVector{typeof(x)}()
+
+# ismissing
+Base.count(f::typeof(ismissing), a::AcceleratedArray) = count(isequal(missing), a)
+Base.findall(f::typeof(ismissing), a::AcceleratedArray) = findall(isequal(missing), a)
+Base.findfirst(f::typeof(ismissing), a::AcceleratedArray) = findfirst(isequal(missing), a)
+Base.findlast(f::typeof(ismissing), a::AcceleratedArray) = findlast(isequal(missing), a)
+Base.filter(f::typeof(ismissing), a::AcceleratedArray) = filter(isequal(missing), a)
+
+# TODO isnan, iszero, isone, isfinite (all are slightly strange when considering things like Complex, Matrix and String)


### PR DESCRIPTION
It's super common to count or search for or filter data using predicates other than `isequal` or `isless`, and we should really support things like `==` (e.g. `count(==(0), vector)`)

The interesting thing is that it's not clear if we even _can_ accelerate something like `==` in theory, because in _theory_ there are no constraints on the relationship of `==` and `isequal`, so having a dictionary of values (where dictionaries use `isequal` comparisons) doesn't necessarily make things faster. However, ignoring theory, in _practice_ we can do something dirty that works for common types like `AbstractFloat`.

The appraoch here attempts to be somewhat flexible, allowing one to expand the search space via a new internal `other_equal` function (e.g. `other_equal(0.0) == [-0.0]` but `other_equal(1.0) == []`). We also check for the case that `==(x,x)` is `false`. The approach won't work for `Base` types like `Matrix{Complex{Float64}}` since there is a combinatoric explosion in the search space.

Another crappy thing is the way `count(==(0), vector)` doesn't actually work as advertised here, haha, you need to type `count(==(0.0), vector)`. We also might like to use `count(iszero, vector)` but the search space for `iszero` is a bit hard to define (e.g. `Complex{<:AbstractFloat}` has four distinct values where this is `true`).

Other predicates like `isone` are a pain (besides numbers, we have `isone("")` is `true` but `isone('x')` is an error...).

One way of constraining the search space might be to limit to certain element types. But honestly I believe everything should still function as normal on arrays of `Any` so dispatching on element type can become an antipattern. I suppose it's OK in the case of an acceleration that doesn't impact the result... stronger typing should make things execute faster... hmm...

CC @bkamins this is one of those things that needs to be done to make this package more generally usable