### PR TITLE
Update Julia compat to 1.6 - 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "AcceleratedArrays"
 uuid = "44e12807-9a19-5591-91cf-c1b4fb89ce64"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
@@ -14,6 +14,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
-julia = "1"
+julia = "1.6 - 1.10"
 SplitApplyCombine = "1"
-Dictionaries = "0.3"
+Dictionaries = "0.4.1 - 0.4"


### PR DESCRIPTION
This is to account for the changes I suggested in this [Dictionaries.jl PR](https://github.com/andyferris/Dictionaries.jl/pull/138) where I'm updating the compat here to use the latest Dictionaries version